### PR TITLE
Remove most elm-analyse warnings

### DIFF
--- a/src/Camperdown/Config/Configurations.elm
+++ b/src/Camperdown/Config/Configurations.elm
@@ -6,13 +6,15 @@ module Camperdown.Config.Configurations exposing (l0, markup, minimal, standard)
 import Camperdown.Config.Build as Build exposing (build, parserConfigFromResult)
 import Camperdown.Config.Config exposing (ParserConfig)
 import Camperdown.Occurs exposing (Occurs(..))
-import Set exposing (Set)
+import Set
 
 
+standard : ParserConfig
 standard =
     Camperdown.Config.Config.config
 
 
+markup : ParserConfig
 markup =
     parserConfigFromResult <|
         build
@@ -25,6 +27,7 @@ markup =
             ]
 
 
+minimal : ParserConfig
 minimal =
     Build.minimal
 

--- a/src/Camperdown/Parse.elm
+++ b/src/Camperdown/Parse.elm
@@ -1,8 +1,9 @@
 module Camperdown.Parse exposing (parse)
 
-{-| Placeholder 
+{-| Placeholder
 
 @docs parse
+
 -}
 
 import Camperdown.Config.Config as Config


### PR DESCRIPTION
The remaining ones are TODO comments that are actual things that are yet to do.